### PR TITLE
Patches for issues #5 and #6

### DIFF
--- a/TEgenomeSimulator/TEgenomeSimulator.py
+++ b/TEgenomeSimulator/TEgenomeSimulator.py
@@ -4,6 +4,7 @@ import argparse
 import subprocess
 from pathlib import Path
 from Bio import SeqIO
+from datetime import datetime
 
 # Function to check if the mode is 1 (user-provided genome) or 0 (random genome)
 def mode_check(value):
@@ -327,6 +328,23 @@ def main():
     # Parse arguments
     args = parser.parse_args()
 
+    # Convert user-provided output path to absolute path
+    outdir = Path(args.outdir).resolve()
+    
+    # Specify final output dir for each project
+    final_out = outdir / f"TEgenomeSimulator_{args.prefix}_result"
+    Path(final_out).mkdir(parents=True, exist_ok=True)
+    
+    # Set up path to log file
+    log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+
+    # Create and initialize the log file early
+    with open(log_path, "w") as log_file:
+        log_file.write(f"[{datetime.now()}] TEgenomeSimulator started.\n")
+        log_file.write(f"[{datetime.now()}] Arguments: {vars(args)}\n")
+
+    print(f"Output Directory: {outdir}")
+
     # Mode-based validation
     if args.mode == 0:
         # Mode 0 requires --chridx to be specified
@@ -383,14 +401,6 @@ def main():
         print(f"TE copy number, mean sequence identity, sd, and max chance of intact insertion evaluated from repeatmasker output.")
 
     print(f"Seed: {args.seed}")
-    
-    # Convert user-provided output path to absolute path
-    outdir = Path(args.outdir).resolve()
-    print(f"Output Directory: {outdir}")
-    
-    # Specify final output dir for each project
-    final_out = outdir / f"TEgenomeSimulator_{args.prefix}_result"
-    Path(final_out).mkdir(parents=True, exist_ok=True)
 
     # Call the prep_sim_TE_lib.py script to generate the TE library table
     if args.mode == 0 or args.mode == 1: 

--- a/TEgenomeSimulator/TEgenomeSimulator.py
+++ b/TEgenomeSimulator/TEgenomeSimulator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from Bio import SeqIO
 from datetime import datetime
 
-# Use Tee to duplicate stdout and stderr to log file
+# Use Tee to duplicate stdout to log file
 class TeeLogger:
     def __init__(self, log_file_path):
         self.terminal = sys.stdout
@@ -19,6 +19,23 @@ class TeeLogger:
     def flush(self):
         self.terminal.flush()
         self.log.flush()
+
+# Use Tee to duplicate stderr to log file
+class TeeErrorLogger:
+    def __init__(self, log_file_path):
+        self.terminal_err = sys.__stderr__
+        self.log = open(log_file_path, "a")
+
+    def write(self, message):
+        for line in message.rstrip().splitlines():
+            timestamped_line = f"[{datetime.now()}] {line}\n"
+            self.terminal_err.write(timestamped_line)
+            self.log.write(timestamped_line)
+
+    def flush(self):
+        self.terminal_err.flush()
+        self.log.flush()
+
 
 # Function to check if the mode is 1 (user-provided genome) or 0 (random genome)
 def mode_check(value):
@@ -354,11 +371,12 @@ def main():
 
     # Create and initialize the log file early
     with open(log_path, "w") as log_file:
-        log_file.write(f"[{datetime.now()}] TEgenomeSimulator started.\n")
-        log_file.write(f"[{datetime.now()}] Arguments: {vars(args)}\n")
+        print(f"[{datetime.now()}] TEgenomeSimulator started.")
+        print(f"[{datetime.now()}] Arguments: {vars(args)}")
 
-    # Redirect stdout to TeeLogger after initialization
+    # Redirect stdout and stderr to TeeLogger after initialization
     sys.stdout = TeeLogger(log_path)
+    sys.stderr = TeeErrorLogger(log_path)
 
     print(f"Output Directory: {outdir}", flush=True)
 

--- a/TEgenomeSimulator/TEgenomeSimulator.py
+++ b/TEgenomeSimulator/TEgenomeSimulator.py
@@ -383,10 +383,13 @@ def main():
         print(f"TE copy number, mean sequence identity, sd, and max chance of intact insertion evaluated from repeatmasker output.")
 
     print(f"Seed: {args.seed}")
-    print(f"Output Directory: {args.outdir}")
     
-    # Specify output dir for each project
-    final_out = args.outdir + "/TEgenomeSimulator_" + args.prefix + "_result"
+    # Convert user-provided output path to absolute path
+    outdir = Path(args.outdir).resolve()
+    print(f"Output Directory: {outdir}")
+    
+    # Specify final output dir for each project
+    final_out = outdir / f"TEgenomeSimulator_{args.prefix}_result"
     Path(final_out).mkdir(parents=True, exist_ok=True)
 
     # Call the prep_sim_TE_lib.py script to generate the TE library table

--- a/TEgenomeSimulator/TEgenomeSimulator.py
+++ b/TEgenomeSimulator/TEgenomeSimulator.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from Bio import SeqIO
 from datetime import datetime
+import subprocess
 
 # Use Tee to duplicate stdout to log file
 class TeeLogger:
@@ -36,6 +37,25 @@ class TeeErrorLogger:
         self.terminal_err.flush()
         self.log.flush()
 
+# Print subprocess output to both console and log
+def run_subprocess_and_tee_output(command, log_path):
+    """Run a subprocess and tee its output to both console and log file."""
+    with open(log_path, "a") as log_file:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True
+        )
+
+        for line in process.stdout:
+            print(line, end='')          # Goes to TeeLogger, so both log and console
+            log_file.flush()             # Flush to write immediately
+
+        process.wait()
+
+        if process.returncode != 0:
+            raise subprocess.CalledProcessError(process.returncode, command)
 
 # Function to check if the mode is 1 (user-provided genome) or 0 (random genome)
 def mode_check(value):
@@ -57,9 +77,9 @@ def run_TE_stitch(prefix, te_lib, outdir):
         ]
         
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(te_stitch_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(te_stitch_command, log_path)
+
         print(f"\nStitching TE successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
@@ -82,9 +102,9 @@ def run_mask_TE(prefix, threads, stitched_telib, unmasked_genome, outdir):
         ]
         
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(mask_te_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(mask_te_command, log_path)
+
         print(f"\nMasking and removing TE successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
@@ -103,9 +123,9 @@ def run_fix_empty_seq(prefix, non_te_genome, outdir):
         ]
         
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(fix_empty_seq_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(fix_empty_seq_command, log_path)
+
         print(f"\nChecking empty sequences successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
@@ -164,9 +184,9 @@ def run_summarise_rm_out(prefix, rmasker_tbl, libindex, rmasker_out, outdir):
         ]
         
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(summarise_rm_out_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(summarise_rm_out_command, log_path)
+
         print(f"\nSummarising TE composition successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
@@ -196,9 +216,9 @@ def run_prep_sim_TE_lib(prefix, repeat, maxcp, mincp, maxidn, minidn, maxsd, min
         ]
         
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "w") as log_file:
-            subprocess.run(prep_telib_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(prep_telib_command, log_path)
+
         print(f"\nTE library table generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
@@ -219,9 +239,9 @@ def prep_sim_TE_lib_mode2(prefix, rmout_summary, seed, outdir):
         ]
         
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(prep_telib_m2_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(prep_telib_m2_command, log_path)
+
         print(f"\nTE library table for mode 2 generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
@@ -245,9 +265,9 @@ def run_prep_config_random(prefix, chridx, repeat, te_table, seed, outdir):
         ]
 
         # Run the command and append the output to the log file
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(prep_yml_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(prep_yml_command, log_path)
+
         print(f"\nConfig file generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
         
     except subprocess.CalledProcessError as e:
@@ -271,10 +291,10 @@ def run_prep_config_custom(prefix, genome, repeat, te_table, seed, outdir):
         ]
             
         # Run the command and append the output to the log file
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(prep_yml_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-            
-            print(f"\nConfig file generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(prep_yml_command, log_path)    
+        
+        print(f"\nConfig file generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
         
     except subprocess.CalledProcessError as e:
         print(f"\nError occurred while running prep_yml_config.py: {e}", flush=True)
@@ -296,9 +316,9 @@ def run_TE_sim_random_insertion(mode, prefix, alpha, beta, outdir):
         ]
 
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(prep_sim_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(prep_sim_command, log_path)
+
         print(f"\nGenome with non-overlap random TE insertions was generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
@@ -321,9 +341,9 @@ def run_TE_sim_nested_insertion(mode, prefix, alpha, beta, outdir):
         ]
 
         # Run the command and capture the output
-        with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
-            subprocess.run(prep_nest_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-        
+        log_path = os.path.join(final_out, "TEgenomeSimulator.log")
+        run_subprocess_and_tee_output(prep_nest_command, log_path)
+
         print(f"\nGenome with non-overlap random and nested TE insertions was generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:

--- a/TEgenomeSimulator/TEgenomeSimulator.py
+++ b/TEgenomeSimulator/TEgenomeSimulator.py
@@ -6,6 +6,20 @@ from pathlib import Path
 from Bio import SeqIO
 from datetime import datetime
 
+# Use Tee to duplicate stdout and stderr to log file
+class TeeLogger:
+    def __init__(self, log_file_path):
+        self.terminal = sys.stdout
+        self.log = open(log_file_path, "a")  # use "a" to append, assuming log already initialized
+
+    def write(self, message):
+        self.terminal.write(message)
+        self.log.write(message)
+
+    def flush(self):
+        self.terminal.flush()
+        self.log.flush()
+
 # Function to check if the mode is 1 (user-provided genome) or 0 (random genome)
 def mode_check(value):
     if value not in ['0', '1', '2']:
@@ -29,10 +43,10 @@ def run_TE_stitch(prefix, te_lib, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(te_stitch_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nStitching TE successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nStitching TE successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running TE_stitch.py: {e}")
+        print(f"\nError occurred while running TE_stitch.py: {e}", flush=True)
         sys.exit(1)
 
 
@@ -54,10 +68,10 @@ def run_mask_TE(prefix, threads, stitched_telib, unmasked_genome, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(mask_te_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nMasking and removing TE successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nMasking and removing TE successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running mask_TE.py: {e}")
+        print(f"\nError occurred while running mask_TE.py: {e}", flush=True)
         sys.exit(1)
 
 # Function to call fix_empty_seq.py to mask and remove TE nucleodites
@@ -75,10 +89,10 @@ def run_fix_empty_seq(prefix, non_te_genome, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(fix_empty_seq_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nChecking empty sequences successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nChecking empty sequences successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running fix_empty_seq.py: {e}")
+        print(f"\nError occurred while running fix_empty_seq.py: {e}", flush=True)
         sys.exit(1)
 
 
@@ -136,10 +150,10 @@ def run_summarise_rm_out(prefix, rmasker_tbl, libindex, rmasker_out, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(summarise_rm_out_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nSummarising TE composition successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nSummarising TE composition successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running summarise_rm_out.py: {e}")
+        print(f"\nError occurred while running summarise_rm_out.py: {e}", flush=True)
         sys.exit(1)
 
 
@@ -168,10 +182,10 @@ def run_prep_sim_TE_lib(prefix, repeat, maxcp, mincp, maxidn, minidn, maxsd, min
         with open(f"{final_out}/TEgenomeSimulator.log", "w") as log_file:
             subprocess.run(prep_telib_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nTE library table generated successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nTE library table generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running prep_sim_TE_lib.py: {e}")
+        print(f"\nError occurred while running prep_sim_TE_lib.py: {e}", flush=True)
         sys.exit(1)
 
 def prep_sim_TE_lib_mode2(prefix, rmout_summary, seed, outdir):
@@ -191,10 +205,10 @@ def prep_sim_TE_lib_mode2(prefix, rmout_summary, seed, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(prep_telib_m2_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nTE library table for mode 2 generated successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nTE library table for mode 2 generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running prep_sim_TE_lib_mode2.py: {e}")
+        print(f"\nError occurred while running prep_sim_TE_lib_mode2.py: {e}", flush=True)
         sys.exit(1)
 
 # Function to call the prep_yml_config.py script for Random Genome Mode
@@ -217,10 +231,10 @@ def run_prep_config_random(prefix, chridx, repeat, te_table, seed, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(prep_yml_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nConfig file generated successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nConfig file generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
         
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running prep_yml_config.py: {e}")
+        print(f"\nError occurred while running prep_yml_config.py: {e}", flush=True)
         sys.exit(1)
 
 # Function to call the prep_yml_config.py script for Custom Genome Mode
@@ -243,10 +257,10 @@ def run_prep_config_custom(prefix, genome, repeat, te_table, seed, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(prep_yml_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
             
-            print(f"\nConfig file generated successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+            print(f"\nConfig file generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
         
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running prep_yml_config.py: {e}")
+        print(f"\nError occurred while running prep_yml_config.py: {e}", flush=True)
         sys.exit(1)
 
 # Function to call TE_sim_random_insertion.py for non-overlape random TE insertion
@@ -268,10 +282,10 @@ def run_TE_sim_random_insertion(mode, prefix, alpha, beta, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(prep_sim_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nGenome with non-overlap random TE insertions was generated successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nGenome with non-overlap random TE insertions was generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running prep_sim_TE_lib.py: {e}")
+        print(f"\nError occurred while running prep_sim_TE_lib.py: {e}", flush=True)
         sys.exit(1)
 
 # Function to call for nested TE insertion
@@ -293,10 +307,10 @@ def run_TE_sim_nested_insertion(mode, prefix, alpha, beta, outdir):
         with open(f"{final_out}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(prep_nest_command, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nGenome with non-overlap random and nested TE insertions was generated successfully. Output logged to {final_out}/TEgenomeSimulator.log")
+        print(f"\nGenome with non-overlap random and nested TE insertions was generated successfully. Output logged to {final_out}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running prep_sim_TE_lib.py: {e}")
+        print(f"\nError occurred while running prep_sim_TE_lib.py: {e}", flush=True)
         sys.exit(1)
 
 
@@ -343,64 +357,67 @@ def main():
         log_file.write(f"[{datetime.now()}] TEgenomeSimulator started.\n")
         log_file.write(f"[{datetime.now()}] Arguments: {vars(args)}\n")
 
-    print(f"Output Directory: {outdir}")
+    # Redirect stdout to TeeLogger after initialization
+    sys.stdout = TeeLogger(log_path)
+
+    print(f"Output Directory: {outdir}", flush=True)
 
     # Mode-based validation
     if args.mode == 0:
         # Mode 0 requires --chridx to be specified
         if not args.chridx:
-            print("Error: When --mode 0 is selected, --chridx must also be specified.")
+            print("Error: When --mode 0 is selected, --chridx must also be specified.", flush=True)
             sys.exit(1)
     elif args.mode == 1:
         # Mode 1 requires --genome to be specified
         if not args.genome:
-            print("Error: When --mode 1 is selected, --genome must also be specified.")
+            print("Error: When --mode 1 is selected, --genome must also be specified.", flush=True)
             sys.exit(1)
         # If --to_mask is specified, then --repeat2 must also be provided
         if args.to_mask and not args.repeat2:
-            print("Error: When --mode 1 is selected and --to_mask is specified, --repeat2 must also be provided.")
+            print("Error: When --mode 1 is selected and --to_mask is specified, --repeat2 must also be provided.", flush=True)
             sys.exit(1)
     elif args.mode == 2:
         # Mode 2 requires --genome and --repeat2 to be specified
         if not args.genome or not args.repeat2:
-            print("Error: When --mode 2 is selected, --genome and --repeat2 must also be specified.")
+            print("Error: When --mode 2 is selected, --genome and --repeat2 must also be specified.", flush=True)
             sys.exit(1)
 
 
     # Output parsed arguments (for demonstration)
-    print(f"Mode: {args.mode}")
+    print(f"Mode: {args.mode}", flush=True)
     if args.mode == 0:
-        print(f"Running Random Synthesized mode.")
+        print(f"Running Random Synthesized mode.", flush=True)
     elif args.mode == 1:
-        print(f"Running Custom Genome mode.")
+        print(f"Running Custom Genome mode.", flush=True)
         if args.to_mask:
-            print(f"To mask genome? {args.to_mask} enabled. Yes.")
+            print(f"To mask genome? {args.to_mask} enabled. Yes.", flush=True)
         else:
             print(f"To mask genome? No.")
     elif args.mode == 2:
-        print(f"Running Genome Approximation mode. TEgenomeSimulator will mask the genome under this mode.")
+        print(f"Running Genome Approximation mode. TEgenomeSimulator will mask the genome under this mode.", flush=True)
         
-    print(f"Prefix: {args.prefix}")
-    print(f"Repeat: {args.repeat}")
+    print(f"Prefix: {args.prefix}", flush=True)
+    print(f"Repeat: {args.repeat}", flush=True)
     if args.mode == 1 or args.mode == 2:
-        print(f"Repeat2: {args.repeat2}")
-    print(f"Chromosome Index: {args.chridx}")
-    print(f"Genome File: {args.genome}")
-    print(f"Alpha: {args.alpha}")
-    print(f"Beta: {args.beta}")
+        print(f"Repeat2: {args.repeat2}", flush=True)
+    print(f"Chromosome Index: {args.chridx}", flush=True)
+    print(f"Genome File: {args.genome}", flush=True)
+    print(f"Alpha: {args.alpha}", flush=True)
+    print(f"Beta: {args.beta}", flush=True)
 
     if args.mode == 0 or args.mode == 1:
-        print(f"Max Copies: {args.maxcp}")
-        print(f"Min Copies: {args.mincp}")        
-        print(f"Upper bound of mean identity: {args.maxidn}")
-        print(f"Lower bound of mean identity: {args.minidn}")
-        print(f"Upper bound of sd of mean identity: {args.maxsd}")
-        print(f"Lower bound of sd of mean ideneity: {args.minsd}")
-        print(f"Max chance of intact insertion: {args.intact}")
+        print(f"Max Copies: {args.maxcp}", flush=True)
+        print(f"Min Copies: {args.mincp}", flush=True)        
+        print(f"Upper bound of mean identity: {args.maxidn}", flush=True)
+        print(f"Lower bound of mean identity: {args.minidn}", flush=True)
+        print(f"Upper bound of sd of mean identity: {args.maxsd}", flush=True)
+        print(f"Lower bound of sd of mean ideneity: {args.minsd}", flush=True)
+        print(f"Max chance of intact insertion: {args.intact}", flush=True)
     else:
-        print(f"TE copy number, mean sequence identity, sd, and max chance of intact insertion evaluated from repeatmasker output.")
+        print(f"TE copy number, mean sequence identity, sd, and max chance of intact insertion evaluated from repeatmasker output.", flush=True)
 
-    print(f"Seed: {args.seed}")
+    print(f"Seed: {args.seed}", flush=True)
 
     # Call the prep_sim_TE_lib.py script to generate the TE library table
     if args.mode == 0 or args.mode == 1: 
@@ -409,25 +426,25 @@ def main():
     # Call the prep_yml_config.py script to generate the config file using the TE library table generated from previous step or from the repeatmasker summary file
     te_table = os.path.join(final_out, "TElib_sim_list.table")
     if args.mode == 0:
-        print("mode=0, running prep_yml_config.py for Random Genome Mode.")
+        print("mode=0, running prep_yml_config.py for Random Genome Mode.", flush=True)
         run_prep_config_random(args.prefix, args.chridx, args.repeat, te_table, args.seed, args.outdir)
 
     elif args.mode == 1:
         if not args.to_mask: 
             print("mode=1, and --to_mask not specified, assumming user-provided genome is TE-depleted.", 
-                  "Running prep_yml_config.py for Custom Genome Mode.") 
+                  "Running prep_yml_config.py for Custom Genome Mode.", flush=True) 
             run_prep_config_custom(args.prefix, args.genome, args.repeat, te_table, args.seed, args.outdir)
         else: 
             # when --to_mask is enabled
             print("mode=1, and --to_mask is specified, assumming user-provided genome is not TE-depleted.", 
-                  "Running mask_TE.py before prep_yml_config.py for Custom Genome Mode.")            
+                  "Running mask_TE.py before prep_yml_config.py for Custom Genome Mode.", flush=True)            
             run_TE_stitch(args.prefix, args.repeat2, args.outdir)
             fixed_non_te_genome = to_mask(args, final_out)
             run_prep_config_custom(args.prefix, fixed_non_te_genome, args.repeat, te_table, args.seed, args.outdir)
 
     elif args.mode == 2:
         print("mode=2, summarising TE composition and masking TE in user-provided genome.", 
-              "Running mask_TE.py and summarise_rm_out.py before prep_yml_config.py for Custom Genome Mode.")
+              "Running mask_TE.py and summarise_rm_out.py before prep_yml_config.py for Custom Genome Mode.", flush=True)
         # --to_mask is enabled under this mode
         fixed_non_te_genome = to_mask(args, final_out)
         # Specify the required input files for run_summarise_rm_out()

--- a/TEgenomeSimulator/utils/TE_sim_nested_insertion.py
+++ b/TEgenomeSimulator/utils/TE_sim_nested_insertion.py
@@ -248,16 +248,16 @@ def main():
     beta = args.beta
     out_dir = args.outdir
     
-    print("\n")
-    print("##############################################################")
-    print("### Mutate TE sequence and perform non-overlap TE insertion###")
-    print("##############################################################")
-    print(f"Using mode {mode} (0 for random genome; 1 for custome genome)")
+    print("\n", flush=True)
+    print("##############################################################", flush=True)
+    print("### Mutate TE sequence and perform non-overlap TE insertion###", flush=True)
+    print("##############################################################", flush=True)
+    print(f"Using mode {mode} (0 for random genome; 1 for custome genome)", flush=True)
 
     # Config file
     final_out = out_dir + '/TEgenomeSimulator_' + prefix + '_result'
     yml_file = "TEgenomeSimulator_" + str(prefix) + ".yml"
-    print(f"Using config file {yml_file}")
+    print(f"Using config file {yml_file}", flush=True)
 
     # Mode-dependent config file loading
     if args.mode == 0:

--- a/TEgenomeSimulator/utils/TE_sim_random_insertion.py
+++ b/TEgenomeSimulator/utils/TE_sim_random_insertion.py
@@ -465,16 +465,16 @@ def main():
     beta = args.beta
     out_dir = args.outdir
     
-    print("\n")
-    print("##############################################################")
-    print("### Mutate TE sequence and perform non-overlap TE insertion###")
-    print("##############################################################")
-    print(f"Using mode {mode} (0 for random genome; 1 for custome genome)")
+    print("\n", flush=True)
+    print("##############################################################", flush=True)
+    print("### Mutate TE sequence and perform non-overlap TE insertion###", flush=True)
+    print("##############################################################", flush=True)
+    print(f"Using mode {mode} (0 for random genome; 1 for custome genome)", flush=True)
 
     # Config file
     final_out = out_dir + '/TEgenomeSimulator_' + prefix + '_result'
     yml_file = "TEgenomeSimulator_" + str(prefix) + ".yml"
-    print(f"Using config file {yml_file}")
+    print(f"Using config file {yml_file}", flush=True)
 
     # Mode-dependent config file loading
     if args.mode == 0:

--- a/TEgenomeSimulator/utils/TE_stitch.py
+++ b/TEgenomeSimulator/utils/TE_stitch.py
@@ -105,7 +105,7 @@ for te_id, parts in te_dict.items():
 # Write the modified sequences to the output file
 SeqIO.write(new_records, Path(final_out, output_fasta), "fasta")
 
-print(f"Stitched FASTA saved as {output_fasta}")
+print(f"Stitched FASTA saved as {output_fasta}", flush=True)
 
 # Index stitched TE library
 input_file = Path(final_out, output_fasta)

--- a/TEgenomeSimulator/utils/fix_empty_seq.py
+++ b/TEgenomeSimulator/utils/fix_empty_seq.py
@@ -25,13 +25,13 @@ def add_random_nucleotides(fasta_file, output_file):
             # Randomly add two nucleotides
             random_seq = random.choice(nucleotides) + random.choice(nucleotides)
             record.seq = Seq(random_seq)  # Wrap the string in a Seq object
-            print(f"Modified {record.id} with sequence: {random_seq}")
+            print(f"Modified {record.id} with sequence: {random_seq}", flush=True)
 
         modified_sequences.append(record)
 
     # Write the modified sequences to a new FASTA file
     SeqIO.write(modified_sequences, output_file, "fasta")
-    print(f"Modified FASTA saved to {output_file}")
+    print(f"Modified FASTA saved to {output_file}", flush=True)
 
 # Input and output file names
 input_fasta = sys.argv[1]

--- a/TEgenomeSimulator/utils/mask_TE.py
+++ b/TEgenomeSimulator/utils/mask_TE.py
@@ -59,10 +59,10 @@ def run_repeatmasker(threads, namelib, namefa, outdir):
         with open(f"{outdir}/TEgenomeSimulator.log", "a") as log_file:
             subprocess.run(cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT)
         
-        print(f"\nRunning RepeatMasker successfully. Output logged to {outdir}/TEgenomeSimulator.log")
+        print(f"\nRunning RepeatMasker successfully. Output logged to {outdir}/TEgenomeSimulator.log", flush=True)
     
     except subprocess.CalledProcessError as e:
-        print(f"\nError occurred while running fix_empty_seq.py: {e}")
+        print(f"\nError occurred while running fix_empty_seq.py: {e}", flush=True)
         sys.exit(1)
 
 
@@ -82,7 +82,7 @@ def convert_fasta_to_single_line(input_fasta):
         for record in SeqIO.parse(input_fasta, "fasta"):
             out_file.write(f">{record.id}\n{str(record.seq)}\n")
 
-    print(f"\nRunning convert_fasta_to_single_line() successfully.")
+    print(f"\nRunning convert_fasta_to_single_line() successfully.", flush=True)
 
 
 def remove_te(input_fasta):
@@ -95,7 +95,7 @@ def remove_te(input_fasta):
     Returns:
         str: Path to the output file with 'X' removed.
     """
-    print(f"\nStarting to remove TE nucleotides using remove_te() function.")
+    print(f"\nStarting to remove TE nucleotides using remove_te() function.", flush=True)
 
     # Generate the output file name
     output_file = f"../{os.path.basename(input_fasta)}.nonTE"
@@ -111,7 +111,7 @@ def remove_te(input_fasta):
     # Print the full path of the output file
     full_output_path = os.path.abspath(output_file)
 
-    print(f"\nTE nucleotides were removed successfully. Output saved to {full_output_path}.")
+    print(f"\nTE nucleotides were removed successfully. Output saved to {full_output_path}.", flush=True)
     
 
 

--- a/TEgenomeSimulator/utils/prep_sim_TE_lib.py
+++ b/TEgenomeSimulator/utils/prep_sim_TE_lib.py
@@ -46,12 +46,12 @@ intact = args.intact
 seed = args.seed
 out_dir = args.outdir
 
-print("\n")
-print("#########################################################")
-print("### Prepare TE library table with simulation settings ###")
-print("#########################################################")
-print(f"Using repeat fasta file {args.repeat}")
-print(f"Output directory set as {args.outdir}")
+print("\n", flush=True)
+print("#########################################################", flush=True)
+print("### Prepare TE library table with simulation settings ###", flush=True)
+print("#########################################################", flush=True)
+print(f"Using repeat fasta file {args.repeat}", flush=True)
+print(f"Output directory set as {args.outdir}", flush=True)
 
 #Set seed
 if seed:
@@ -103,8 +103,8 @@ for sup_fam in te_superfamily:
 #     te_subclass.append(subclass)
      
 # count
-print("\n")
-print("## Random chosing copy numbe for each TE family ##")
+print("\n", flush=True)
+print("## Random chosing copy numbe for each TE family ##", flush=True)
 copy_number = []
 minimum = min_cp
 maximum = max_cp
@@ -112,12 +112,12 @@ n = len(te_family)
 for i in range(n):
     random_num = random.choice(range(minimum, maximum + 1))
     copy_number.append(random_num)
-print(f"Maximum copy number set by user: {args.maxcp}")
-print(f"Minimum copy number set by user: {args.maxcp}")
+print(f"Maximum copy number set by user: {args.maxcp}", flush=True)
+print(f"Minimum copy number set by user: {args.maxcp}", flush=True)
 
 # identity
-print("\n")
-print("## Random chosing the averaged sequence identity for each TE family ##")
+print("\n", flush=True)
+print("## Random chosing the averaged sequence identity for each TE family ##", flush=True)
 identity = []
 minimum = min_idn #default 80
 maximum = max_idn #default 95
@@ -125,12 +125,12 @@ n = len(te_family)
 for i in range(n):
     random_num = random.choice(range(minimum, maximum + 1))
     identity.append(random_num)
-print(f"Maximum averaged sequence identity: {maximum}")
-print(f"Minimum averaged sequence identity: {minimum}")
+print(f"Maximum averaged sequence identity: {maximum}", flush=True)
+print(f"Minimum averaged sequence identity: {minimum}", flush=True)
 
 # standard deviation of identity
-print("\n")
-print("## Random chosing the standard deviation of averaged sequence identity for each TE family ##")
+print("\n", flush=True)
+print("## Random chosing the standard deviation of averaged sequence identity for each TE family ##", flush=True)
 sd = []
 minimum = min_sd #default 1
 maximum = max_sd #default 20
@@ -138,12 +138,12 @@ n = len(te_family)
 for i in range(n):
     random_num = random.choice(range(minimum, maximum + 1))
     sd.append(random_num)
-print(f"Maximum standard deviation of averaged sequence identity: {maximum}")
-print(f"Minimum standard deviation of averaged sequence identity: {minimum}")
+print(f"Maximum standard deviation of averaged sequence identity: {maximum}", flush=True)
+print(f"Minimum standard deviation of averaged sequence identity: {minimum}", flush=True)
     
 # indel (as a proportion to total SNP = substitution + indel)
-print("\n")
-print("## Random chosing the proportion of INDEL to total SNP (dependant on sequence identity) for each TE family ##")
+print("\n", flush=True)
+print("## Random chosing the proportion of INDEL to total SNP (dependant on sequence identity) for each TE family ##", flush=True)
 indel = []
 minimum = 5
 maximum = 20
@@ -151,12 +151,12 @@ n = len(te_family)
 for i in range(n):
     random_num = random.choice(range(minimum, maximum + 1))
     indel.append(random_num)
-print(f"Maximum INDEL proportion set by default: {maximum}")
-print(f"Minimum INDEL proportion set by default: {minimum}")
+print(f"Maximum INDEL proportion set by default: {maximum}", flush=True)
+print(f"Minimum INDEL proportion set by default: {minimum}", flush=True)
     
 # tsd (use prior knowledge)
-print("\n")
-print("## Setting the length of std based on prior knowledge ##")
+print("\n", flush=True)
+print("## Setting the length of std based on prior knowledge ##", flush=True)
 ltr_retro = ['LTR/Copia', 'LTR/Gypsy', 'LTR/Ty3', 'LTR/Solo', 'LTR/unknown'] 
 line = ['LINE/unknown', 'LINE/L1']
 sine = ['SINE/unknown', 'SINE/tRNA']
@@ -194,29 +194,29 @@ for sup_fam in te_superfamily:
         tsd_range = '0,0'
     tsd.append(str(tsd_range))
 
-print("Length range of TSD for LTR retrotransposon set to: 5 - 5")
-print("Length range of TSD for LINE set to: 5 - 20")
-print("Length range of TSD for SINE set to: 5 - 20")
-print("Length range of TSD for DTA set to: 5 - 8")
-print("Length range of TSD for DTC set to: 2 - 4")
-print("Length range of TSD for DTH set to: 3 - 3")
-print("Length range of TSD for DTM set to: 8 - 9")
-print("Length range of TSD for DTT set to: 2 - 2")
-print("Length range of TSD for Helitron set to: 0")
-print("Length range of TSD for MITE set to: 2 - 10")
-print("Length range of TSD for else set to: 0")
+print("Length range of TSD for LTR retrotransposon set to: 5 - 5", flush=True)
+print("Length range of TSD for LINE set to: 5 - 20", flush=True)
+print("Length range of TSD for SINE set to: 5 - 20", flush=True)
+print("Length range of TSD for DTA set to: 5 - 8", flush=True)
+print("Length range of TSD for DTC set to: 2 - 4", flush=True)
+print("Length range of TSD for DTH set to: 3 - 3", flush=True)
+print("Length range of TSD for DTM set to: 8 - 9", flush=True)
+print("Length range of TSD for DTT set to: 2 - 2", flush=True)
+print("Length range of TSD for Helitron set to: 0", flush=True)
+print("Length range of TSD for MITE set to: 2 - 10", flush=True)
+print("Length range of TSD for else set to: 0", flush=True)
 
 # length
-print("\n")
-print("## Extracting the length of each TE family ##")
+print("\n", flush=True)
+print("## Extracting the length of each TE family ##", flush=True)
 length = []
 for te_id in te_lib:
     te_len = len(te_lib[te_id].seq)
     length.append(te_len)
 
 # fragmented TE loci (as a proportion to total TE loci of the family)
-print("\n")
-print("## Setting the proportion of fragmented TE loci of each TE family ##")
+print("\n", flush=True)
+print("## Setting the proportion of fragmented TE loci of each TE family ##", flush=True)
 #min_intact_ratio = 0
 #max_intact_ratio = float(intact)
 # the value of "intact" represent the maximum chance of 
@@ -228,14 +228,14 @@ for i in range(n):
     random_num = np.random.uniform(minimum, maximum)
     #random_num = random.choice(range(minimum, maximum + 1))
     fragment.append(random_num)
-print(f"Maximum chance of keeping a TE insertion intact as 100% integrity in each TE family: {intact}")
-print(f"Minimum chance of keeping a TE insertion intact in each TE family: 0")
-print(f"Maximum proportion of fragmented TE loci of each TE family: {maximum}")
-print(f"Minimum proportion of fragmented TE loci of each TE family: {minimum}")
+print(f"Maximum chance of keeping a TE insertion intact as 100% integrity in each TE family: {intact}", flush=True)
+print(f"Minimum chance of keeping a TE insertion intact in each TE family: 0", flush=True)
+print(f"Maximum proportion of fragmented TE loci of each TE family: {maximum}", flush=True)
+print(f"Minimum proportion of fragmented TE loci of each TE family: {minimum}", flush=True)
 
 # nest TE loci (as a proportion to total TE loci of the family; only apply for Copia and Gypsy)
-print("\n")
-print("## Setting the proportion of nested TE insertion of each Copia or Gypsy family ##")
+print("\n", flush=True)
+print("## Setting the proportion of nested TE insertion of each Copia or Gypsy family ##", flush=True)
 nested = []
 minimum = 0
 maximum = 30
@@ -243,12 +243,12 @@ n = len(te_family)
 for i in range(n):
     random_num = random.choice(range(minimum, maximum + 1))
     nested.append(random_num)
-print(f"Maximum proportion of nested TE insertion of each Copia or Gypsy family set by default: {maximum}")
-print(f"Minimum proportion of nested TE insertion of each Copia or Gypsy family set by default: {minimum}")
+print(f"Maximum proportion of nested TE insertion of each Copia or Gypsy family set by default: {maximum}", flush=True)
+print(f"Minimum proportion of nested TE insertion of each Copia or Gypsy family set by default: {minimum}", flush=True)
 
 # create the table
-print("\n")
-print("## Printing the TE library table ##")
+print("\n", flush=True)
+print("## Printing the TE library table ##", flush=True)
 
 final_out = str(out_dir) + "/TEgenomeSimulator_" + str(prefix) + "_result"
 #Path(out_dir, "TEgenomeSimulator_" + prefix + "_result").mkdir(parents=True, exist_ok=True)
@@ -261,5 +261,5 @@ for i in range(n - 1):
     table_out.write("\t".join([str(te_family[i]), str(te_subclass[i]), str(te_superfamily[i]),  str(copy_number[i]), str(identity[i]), str(sd[i]), str(indel[i]), str(tsd[i]), str(length[i]), str(fragment[i]), str(nested[i]) + "\n"]))
 table_out.close()    
 
-print(f"Generated the TE library table for simulation. File saved as {out_dir}/TElib_sim_list.table")
-print("\n")
+print(f"Generated the TE library table for simulation. File saved as {out_dir}/TElib_sim_list.table", flush=True)
+print("\n", flush=True)

--- a/TEgenomeSimulator/utils/prep_sim_TE_lib_mode2.py
+++ b/TEgenomeSimulator/utils/prep_sim_TE_lib_mode2.py
@@ -11,12 +11,12 @@ rm_outsum = sys.argv[2]
 seed = sys.argv[3]
 out_dir = sys.argv[4]
 
-print("\n")
-print("#########################################################")
-print("### Prepare TE library table with simulation settings ###")
-print("#########################################################")
-print(f"Using repeatmasker output summary file {rm_outsum}")
-print(f"Output directory set as {out_dir}")
+print("\n", flush=True)
+print("#########################################################", flush=True)
+print("### Prepare TE library table with simulation settings ###", flush=True)
+print("#########################################################", flush=True)
+print(f"Using repeatmasker output summary file {rm_outsum}", flush=True)
+print(f"Output directory set as {out_dir}", flush=True)
 
 #Set seed
 if seed:
@@ -110,8 +110,8 @@ for sup_fam in te_superfamily:
 te_sum['nest'] = pd.DataFrame({'nest': nested})
 
 # create the table
-print("\n")
-print("## Printing the TE library table for mode 2 ##") 
+print("\n", flush=True)
+print("## Printing the TE library table for mode 2 ##", flush=True) 
 
 df = te_sum[['original_family', 'subclass', 'superfamily', 'copynumber', 'idn', 'sd', 'indels', 'tsd', 'full_length_bp', 'frag', 'nest', 'integrity_lst']]
 df = df.rename(columns={'original_family': '#TE_family', 'copynumber': 'count', 'full_length_bp': 'length'})
@@ -121,5 +121,5 @@ final_out = str(out_dir) + "/TEgenomeSimulator_" + str(prefix) + "_result"
 output_file = os.path.join(final_out, "TElib_sim_list_mode2.table")
 df.to_csv(output_file, sep='\t', index=False, header=True)
 
-print(f"Generated the TE library table for simulation. File saved as {out_dir}/TElib_sim_list_mode2.table")
-print("\n")
+print(f"Generated the TE library table for simulation. File saved as {out_dir}/TElib_sim_list_mode2.table", flush=True)
+print("\n", flush=True)

--- a/TEgenomeSimulator/utils/prep_yml_config.py
+++ b/TEgenomeSimulator/utils/prep_yml_config.py
@@ -32,13 +32,13 @@ te_table = args.table
 seed = args.seed
 outdir = args.outdir
 
-print("\n")
-print("#############################################")
-print("### Prepare TEgenomeSimulator config file ###")
-print("#############################################")
-print(f"Using genome fasta file {args.genome}")
-print(f"Using repeat fasta file {args.repeat}")
-print(f"Output directory set as {args.outdir}")
+print("\n", flush=True)
+print("#############################################", flush=True)
+print("### Prepare TEgenomeSimulator config file ###", flush=True)
+print("#############################################", flush=True)
+print(f"Using genome fasta file {args.genome}", flush=True)
+print(f"Using repeat fasta file {args.repeat}", flush=True)
+print(f"Output directory set as {args.outdir}", flush=True)
 
 # Generate chromosome dictionary
 if chr_index:
@@ -101,5 +101,5 @@ elif genome_fa:
         i += 1
     config_out.close()
 
-print(f"Generated the config file for simulation. File saved as {outdir}/TEgenomeSimulator_{prefix}.yml")
-print("\n")
+print(f"Generated the config file for simulation. File saved as {outdir}/TEgenomeSimulator_{prefix}.yml", flush=True)
+print("\n", flush=True)

--- a/TEgenomeSimulator/utils/summarise_rm_out.py
+++ b/TEgenomeSimulator/utils/summarise_rm_out.py
@@ -242,7 +242,7 @@ def create_high_level_summary(summary_fam, genome_size, masked_size):
 
 if __name__ == "__main__":
     if len(sys.argv) != 5:
-        print("Usage: python summarise_rm_out.py <RMaskerTbl> <LibIndex> <RMaskerOut>,<OutDir>.")
+        print("Usage: python summarise_rm_out.py <RMaskerTbl> <LibIndex> <RMaskerOut>,<OutDir>.", flush=True)
         sys.exit(1)
     
     rmasker_tbl = sys.argv[1]


### PR DESCRIPTION
- resolving relative path to full absolute path
- created log file at the initiation of the software without waiting subprocess.
- added `flush=True` to all `print()` statements to make sure messages in strict chronological order.
- added the two classes, TeeLogger and TeeErrorLogger, and one function, run_subprocess_and_tee_output, to allow printing stdout and stderr to both the log file and console.