### PR TITLE
Adding Dockerfile for v1.0.0 release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# ignore fasta file
+*.fasta
+
+# ignore gff
+*.gff
+
+# ignore output folder
+./test/output
+
+# ignore apptainer image
+*.sif

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  packages: write
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Docker push
+        run: |
+          export APP_NAME=tegenomesimulator
+          export APP_VERSION=$(grep version setup.py | sed -E "s/.*version=['\"]([^'\"]+)['\"].*/\1/")
+
+          docker build -t ${APP_NAME}:${APP_VERSION} ./docker-recipe/v${APP_VERSION}
+          docker tag ${APP_NAME}:${APP_VERSION} ghcr.io/plant-food-research-open/${APP_NAME}:${APP_VERSION}
+          docker push ghcr.io/plant-food-research-open/${APP_NAME}:${APP_VERSION}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           export APP_NAME=tegenomesimulator
           export APP_VERSION=$(grep version setup.py | sed -E "s/.*version=['\"]([^'\"]+)['\"].*/\1/")
 
-          docker build -t ${APP_NAME}:${APP_VERSION} 
+          docker build -t ${APP_NAME}:${APP_VERSION} ./docker-recipe/v${APP_VERSION}
           docker tag ${APP_NAME}:${APP_VERSION} ghcr.io/plant-food-research-open/${APP_NAME}:${APP_VERSION}
           docker tag ${APP_NAME}:${APP_VERSION} ghcr.io/plant-food-research-open/${APP_NAME}:latest
           

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,10 @@ jobs:
           export APP_NAME=tegenomesimulator
           export APP_VERSION=$(grep version setup.py | sed -E "s/.*version=['\"]([^'\"]+)['\"].*/\1/")
 
-          docker build -t ${APP_NAME}:${APP_VERSION} ./docker-recipe/v${APP_VERSION}
+          docker build -t ${APP_NAME}:${APP_VERSION} 
           docker tag ${APP_NAME}:${APP_VERSION} ghcr.io/plant-food-research-open/${APP_NAME}:${APP_VERSION}
+          docker tag ${APP_NAME}:${APP_VERSION} ghcr.io/plant-food-research-open/${APP_NAME}:latest
+          
           docker push ghcr.io/plant-food-research-open/${APP_NAME}:${APP_VERSION}
+          docker push ghcr.io/plant-food-research-open/${APP_NAME}:latest
+

--- a/apptainer-recipe/v1.0.0/apptainer.def
+++ b/apptainer-recipe/v1.0.0/apptainer.def
@@ -2,7 +2,7 @@ Bootstrap: docker
 From: ubuntu:22.04
 
 %labels
-    Maintainer: ting-hsuan.chen@plandandfood.co.nz
+    Maintainer: ting-hsuan.chen@plantandfood.co.nz
     Version: 1.0.0
     Description: TEgenomeSimulator, a tool to simulate TE mutation and insertion into a random or user-provided genome.
 

--- a/docker-recipe/v1.0.0/Dockerfile
+++ b/docker-recipe/v1.0.0/Dockerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:22.04 AS base
+
+LABEL maintainer=ting-hsuan.chen@plantandfood.co.nz
+
+LABEL description="TEgenomeSimulator, a tool to simulate TE mutation and insertion into a random or user-provided genome."
+
+LABEL version=1.0.0
+
+ENV PATH="/opt/RepeatMasker:/usr/local/bin:$PATH"
+
+WORKDIR /opt
+
+RUN apt-get update \
+    && apt-get install -y \ 
+    build-essential \
+    wget \
+    curl \
+    perl \
+    csh \
+    zlib1g-dev \
+    python3 \
+    python3-pip \
+    samtools \
+    unzip \
+    git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/downloaded_packages
+
+RUN pip3 install numpy==1.26.2 pandas==2.2.1 \
+    biopython==1.81 pyyaml==6.0.1 h5py==3.14.0 matplotlib==3.10.3 
+
+FROM base AS builder
+
+RUN cd /tmp \
+    &&  wget https://www.repeatmasker.org/RepeatMasker/RepeatMasker-4.1.8.tar.gz && \
+    tar -xzf RepeatMasker-4.1.8.tar.gz && \
+    cd RepeatMasker && \
+    mkdir -p Libraries && \
+    mv /tmp/RepeatMasker /opt
+
+RUN cd /tmp \
+    && wget https://www.repeatmasker.org/rmblast/rmblast-2.14.1+-x64-linux.tar.gz && \
+    tar -xzf rmblast-2.14.1+-x64-linux.tar.gz && \
+    mv rmblast-2.14.1 /opt/RMBlast
+
+RUN cd /tmp \
+    && wget https://github.com/Benson-Genomics-Lab/TRF/releases/download/v4.09.1/trf409.linux64 -O trf && \
+    chmod +x trf && \
+    mv trf /opt/RepeatMasker/trf
+
+FROM base AS runtime
+
+COPY --from=builder /opt /opt
+
+RUN cd /opt/RepeatMasker \
+    && echo -e "\n\n" | ./configure \
+    -libdir /opt/RepeatMasker/Libraries \
+    -trf_prgm /opt/RepeatMasker/trf \
+    -rmblast_dir /opt/RepeatMasker/RMBlast/bin \
+    -default_search_engine rmblast
+
+RUN cd /opt && \  
+    git clone --depth 1 --branch v1.0.0 \
+    https://github.com/Plant-Food-Research-Open/TEgenomeSimulator.git && \
+    cd /opt/TEgenomeSimulator && \
+    pip3 install .


### PR DESCRIPTION
closes #7 

- Adding Docker image for v1.0.0 release of [TEgenomeSimulator](https://github.com/Plant-Food-Research-Open/TEgenomeSimulator)
- Adding GitHub Actions pipeline for pushing Docker image to Plant-Food-Research-Open packages
- @ting-hsuan-chen for the GitHub Actions pipeline to work, you must add a secret called **GHCR_TOKEN** from the [TEgenomeSimulator](https://github.com/Plant-Food-Research-Open/TEgenomeSimulator) settings page. This should be a GitHub personal access token with SSO enabled for Plant-Food-Research-Open 
- Adding .dockerignore

![image](https://github.com/user-attachments/assets/377823e8-e3c9-49be-a2f9-9924327a7062)
