### PR TITLE
Adding missing seed for numpy

### DIFF
--- a/TEgenomeSimulator/utils/prep_sim_TE_lib.py
+++ b/TEgenomeSimulator/utils/prep_sim_TE_lib.py
@@ -57,6 +57,7 @@ print(f"Output directory set as {args.outdir}", flush=True)
 #Set seed
 if seed:
     random.seed(seed)
+    np.random.seed(seed)
 
 # Load files
 te_lib = SeqIO.to_dict(SeqIO.parse(te_fa ,"fasta"))

--- a/build/lib/TEgenomeSimulator/utils/prep_sim_TE_lib.py
+++ b/build/lib/TEgenomeSimulator/utils/prep_sim_TE_lib.py
@@ -56,6 +56,7 @@ print(f"Output directory set as {args.outdir}")
 #Set seed
 if seed:
     random.seed(seed)
+    np.random.seed(seed)
 
 # Load files
 te_lib = SeqIO.to_dict(SeqIO.parse(te_fa ,"fasta"))


### PR DESCRIPTION
@ting-hsuan-chen adding missing seed for numpy

Should the simulated sequence data be fully reproducible, assuming that the random seed value is set? I'm having some issues with reproducibility when using sourmash to produce MinHash sketches of the final genome sequences (with the random seed specified for both TEgenomeSimulator and sourmash).

The problem may be with sourmash

I will try again with the latest dev version of TEgenomeSimulator